### PR TITLE
fix bug module call for commands with length >= 2

### DIFF
--- a/Arduino_Files/VoiceRecognitionV3.cpp
+++ b/Arduino_Files/VoiceRecognitionV3.cpp
@@ -1199,6 +1199,8 @@ void VR :: send_pkt(uint8_t cmd, uint8_t *buf, uint8_t len)
 	Serial2.write(len+2);
     delay(TXDLY);
 	Serial2.write(cmd);
+	delay(TXDLY);
+	Serial2.write(buf, len);
     delay(TXDLY);
 	Serial2.write(FRAME_END);
     delay(TXDLY);


### PR DESCRIPTION
Fixing a bug which results in commands with length >= 2 not working as its not beeing sent to the module.